### PR TITLE
Add capability to set max_data_array_size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# To compile this with docker use:
+# docker build --tag turbo_seti .
+# Then to run it:
+# docker run --rm -it turbo_seti
+# To be able to access local disk on Mac OSX, you need to use Docker for Mac GUI
+# and click on 'File sharing', then add your directory, e.g. /data/bl_pks
+# Then to run it:
+# docker run --rm -it -v /data/bl_pks:/mnt/data turbo_seti
+# And if you want to access a port, you need to do a similar thing:
+# docker run --rm -it -p 9876:9876 sigpyproc
+
+# INSTALL BASE FROM KERN SUITE
+FROM kernsuite/base:3
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV TERM xterm
+
+######
+# Do docker apt-installs
+RUN docker-apt-install build-essential python-setuptools python-pip python-tk pkg-config
+RUN docker-apt-install curl wget make cmake git
+RUN docker-apt-install libomp-dev
+RUN docker-apt-install libhdf5-serial-dev libhdf5-dev libhdf5-cpp-11
+
+#####
+# Pip installation of python packages
+RUN pip install --upgrade pip setuptools wheel
+RUN pip install numpy==1.14.1
+RUN pip install pandas cython astropy matplotlib
+RUN pip install --only-binary=scipy scipy
+
+######
+# HDF5 fixup
+# Ubuntu 16.04 has a crazy hdf5 setup, needs some massaging, and extra flags to install h5py
+RUN ln -s /usr/lib/x86_64-linux-gnu/libhdf5_serial.so /usr/lib/x86_64-linux-gnu/libhdf5.so
+RUN ln -s /usr/lib/x86_64-linux-gnu/libhdf5_serial_hl.so /usr/lib/x86_64-linux-gnu/libhdf5_hl.so
+RUN CFLAGS=-I/usr/include/hdf5/serial pip install h5py==2.5.0
+RUN CFLAGS=-I/usr/include/hdf5/serial pip install bitshuffle==0.3.4
+
+
+# Finally, install sigpyproc!
+COPY . .
+RUN python setup.py install
+
+
+
+

--- a/blimpy/file_wrapper.py
+++ b/blimpy/file_wrapper.py
@@ -283,7 +283,8 @@ class H5Reader(Reader):
     """ This class handles .h5 files.
     """
 
-    def __init__(self, filename, f_start=None, f_stop=None, t_start=None, t_stop=None, load_data=True, max_load=None):
+    def __init__(self, filename, f_start=None, f_stop=None, t_start=None, t_stop=None, load_data=True, max_load=None,
+                 max_data_array_size=None):
         """ Constructor.
 
         Args:
@@ -335,8 +336,11 @@ class H5Reader(Reader):
             #Update frequencies ranges from channel number.
             self._setup_freqs()
 
-            # Max size of data array to load into memory (1GB in bytes)
-            MAX_DATA_ARRAY_SIZE_UNIT = 1024 * 1024 * 1024.
+            if max_data_array_size is None:
+                # Max size of data array to load into memory (1GB in bytes)
+                MAX_DATA_ARRAY_SIZE_UNIT = 1024 * 1024 * 1024.
+            else:
+                MAX_DATA_ARRAY_SIZE_UNIT = max_data_array_size
 
             #Applying data size limit to load.
             if max_load is not None:
@@ -453,7 +457,8 @@ class FilReader(Reader):
     """ This class handles .fil files.
     """
 
-    def __init__(self, filename,f_start=None, f_stop=None,t_start=None, t_stop=None, load_data=True, max_load=None):
+    def __init__(self, filename,f_start=None, f_stop=None,t_start=None, t_stop=None, load_data=True, max_load=None,
+                 max_data_array_size=None):
         """ Constructor.
 
         Args:
@@ -507,8 +512,11 @@ class FilReader(Reader):
             # set start of data, at real length of header  (future development.)
 #            self.datastart=self.hdrraw.find('HEADER_END')+len('HEADER_END')+self.startsample*self.channels
 
-            # Max size of data array to load into memory (1GB in bytes)
-            self.MAX_DATA_ARRAY_SIZE_UNIT = 1024 * 1024 * 1024.
+            if max_data_array_size is None:
+                # Max size of data array to load into memory (1GB in bytes)
+                MAX_DATA_ARRAY_SIZE_UNIT = 1024 * 1024 * 1024.
+            else:
+                MAX_DATA_ARRAY_SIZE_UNIT = max_data_array_size
 
             #Applying data size limit to load.
             if max_load is not None:
@@ -516,7 +524,7 @@ class FilReader(Reader):
                     logger.warning('Setting data limit > 1GB, please handle with care!')
                     self.MAX_DATA_ARRAY_SIZE = max_load * MAX_DATA_ARRAY_SIZE_UNIT
             else:
-                self.MAX_DATA_ARRAY_SIZE = self.MAX_DATA_ARRAY_SIZE_UNIT
+                self.MAX_DATA_ARRAY_SIZE = MAX_DATA_ARRAY_SIZE_UNIT
 
             if self.file_size_bytes > self.MAX_DATA_ARRAY_SIZE:
                 self.large_file = True
@@ -727,7 +735,8 @@ class FilReader(Reader):
         return data
 
 
-def open_file(filename, f_start=None, f_stop=None,t_start=None, t_stop=None,load_data=True,max_load=None):
+def open_file(filename, f_start=None, f_stop=None,t_start=None, t_stop=None,
+              load_data=True, max_load=None, max_data_array_size=None):
     """Open a supported file type or fall back to Python built in open function.
 
     ================== ==================================================
@@ -753,10 +762,12 @@ def open_file(filename, f_start=None, f_stop=None,t_start=None, t_stop=None,load
 
     if ext == b'h5':
         # Open HDF5 file
-        return H5Reader(filename, f_start=f_start, f_stop=f_stop, t_start=t_start, t_stop=t_stop, load_data=load_data, max_load=max_load)
+        return H5Reader(filename, f_start=f_start, f_stop=f_stop, t_start=t_start, t_stop=t_stop,
+                        load_data=load_data, max_load=max_load, max_data_array_size=max_data_array_size)
     elif ext == b'fil':
         # Open FIL file
-        return FilReader(filename, f_start=f_start, f_stop=f_stop, t_start=t_start, t_stop=t_stop, load_data=load_data, max_load=max_load)
+        return FilReader(filename, f_start=f_start, f_stop=f_stop, t_start=t_start, t_stop=t_stop, load_data=load_data, max_load=max_load,
+                         max_data_array_size=max_data_array_size)
     else:
         # Fall back to regular Python `open` function
         return open(filename, *args, **kwargs)

--- a/blimpy/file_wrapper.py
+++ b/blimpy/file_wrapper.py
@@ -737,14 +737,16 @@ class FilReader(Reader):
 
 def open_file(filename, f_start=None, f_stop=None,t_start=None, t_stop=None,
               load_data=True, max_load=None, max_data_array_size=None):
-    """Open a supported file type or fall back to Python built in open function.
+    """Open a HDF5 or filterbank file
+
+    Returns instance of a Reader to read data from file.
 
     ================== ==================================================
     Filename extension File type
     ================== ==================================================
-    h5                 HDF5 format
+    h5, hdf5           HDF5 format
     fil                fil format
-    *other*            Open with regular python :func:`open` function.
+    *other*            Will raise NotImplementedError
     ================== ==================================================
 
     """
@@ -760,14 +762,13 @@ def open_file(filename, f_start=None, f_stop=None,t_start=None, t_stop=None,
     if six.PY3:
         ext = bytes(ext, 'ascii')
 
-    if ext == b'h5':
+    if h5py.is_hdf5(filename):
         # Open HDF5 file
         return H5Reader(filename, f_start=f_start, f_stop=f_stop, t_start=t_start, t_stop=t_stop,
                         load_data=load_data, max_load=max_load, max_data_array_size=max_data_array_size)
-    elif ext == b'fil':
+    elif sigproc.is_filterbank(filename):
         # Open FIL file
         return FilReader(filename, f_start=f_start, f_stop=f_stop, t_start=t_start, t_stop=t_stop, load_data=load_data, max_load=max_load,
                          max_data_array_size=max_data_array_size)
     else:
-        # Fall back to regular Python `open` function
-        return open(filename, *args, **kwargs)
+        raise NotImplementedError('Cannot open this type of file with Waterfall')

--- a/blimpy/filterbank.py
+++ b/blimpy/filterbank.py
@@ -264,13 +264,8 @@ class Filterbank(object):
         filesize = os.path.getsize(self.filename)
         n_bytes_data = filesize - self.idx_data
 
-        if n_bits == 2:
-            n_ints_in_file = int(4 * n_bytes_data / (n_chans * n_ifs))
-        else:
-            n_ints_in_file = int(n_bytes_data / (n_bytes * n_chans * n_ifs))
-
         # Finally add some other info to the class as objects
-        self.n_ints_in_file  = n_ints_in_file
+        self.n_ints_in_file  = calc_n_ints_in_file(self.filename)
         self.file_size_bytes = filesize
 
         ## Setup time axis
@@ -916,7 +911,7 @@ class Filterbank(object):
         print("[Filterbank] Warning: Non-standard function to write in filterbank (.fil) format. Please use Waterfall.")
 
         n_bytes  = int(self.header[b'nbits'] / 8)
-        with open(filename_out, "w") as fileh:
+        with open(filename_out, "wb") as fileh:
             fileh.write(generate_sigproc_header(self))
             j = self.data
             if n_bytes == 4:

--- a/blimpy/sigproc.py
+++ b/blimpy/sigproc.py
@@ -211,6 +211,22 @@ def read_next_header_keyword(fh):
                 val = Angle(val, unit=u.deg)
         return keyword, val, idx
 
+def is_filterbank(filename):
+    """ Open file and confirm if it is a filterbank file or not. """
+    with open(filename, 'rb') as fh:
+        is_fil = True
+
+        # Check this is a blimpy file
+        try:
+            keyword, value, idx = read_next_header_keyword(fh)
+            try:
+                assert keyword == b'HEADER_START'
+            except AssertionError:
+                is_fil = False
+        except KeyError:
+            is_fil = False
+        return is_fil
+
 def read_header(filename, return_idxs=False):
     """ Read blimpy header and return a Python dictionary of key:value pairs
 

--- a/blimpy/sigproc.py
+++ b/blimpy/sigproc.py
@@ -3,6 +3,7 @@ import numpy as np
 from astropy import units as u
 from astropy.coordinates import Angle
 import os
+import six
 
 try:
     import h5py
@@ -73,38 +74,6 @@ header_keyword_types = {
     b'src_dej'      : b'angle',
     }
 
-def grab_header(filename):
-    """ Extract the blimpy header from the file
-
-    Args:
-        filename (str): name of file to open
-
-    Returns:
-        header_str (str): blimpy header as a binary string
-    """
-    f = open(filename, 'rb')
-    eoh_found = False
-
-    header_str = ''
-    header_sub_count = 0
-    while not eoh_found:
-        header_sub = f.read(512)
-        header_sub_count += 1
-        if b'HEADER_START' in header_sub:
-            idx_start = header_sub.index(b'HEADER_START') + len(b'HEADER_START')
-            header_sub = header_sub[idx_start:]
-
-        if b'HEADER_END' in header_sub:
-            eoh_found = True
-            idx_end = header_sub.index(b'HEADER_END')
-            header_sub = header_sub[:idx_end]
-
-        if header_sub_count >= MAX_HEADER_BLOCKS:
-            raise RuntimeError("MAX HEADER LENGTH REACHED. THIS FILE IS FUBARRED.")
-        header_str += header_sub
-
-    f.close()
-    return header_str
 
 def len_header(filename):
     """ Return the length of the blimpy header, in bytes
@@ -129,47 +98,6 @@ def len_header(filename):
         idx_end = (header_sub_count -1) * 512 + idx_end
     return idx_end
 
-def parse_header(filename):
-    """ Parse a header of a blimpy, looking for allowed keywords
-
-    Uses header_keyword_types dictionary as a lookup for data types.
-
-    Args:
-        filename (str): name of file to open
-
-    Returns:
-        header_dict (dict): A dictioary of header key:value pairs
-    """
-    header = grab_header(filename)
-    header_dict = {}
-
-    #print header
-    for keyword in header_keyword_types.keys():
-        if keyword in header:
-            dtype = header_keyword_types.get(keyword, b'str')
-            idx = header.index(keyword) + len(keyword)
-            dtype = header_keyword_types[keyword]
-            if dtype == b'<l':
-                val = struct.unpack(dtype, header[idx:idx+4])[0]
-                header_dict[keyword] = val
-            if dtype == b'<d':
-                val = struct.unpack(dtype, header[idx:idx+8])[0]
-                header_dict[keyword] = val
-            if dtype == b'str':
-                str_len = struct.unpack('<L', header[idx:idx+4])[0]
-                str_val = header[idx+4:idx+4+str_len]
-                header_dict[keyword] = str_val
-            if dtype == b'angle':
-                val = struct.unpack('<d', header[idx:idx+8])[0]
-                val = fil_double_to_angle(val)
-
-                if keyword == b'src_raj':
-                    val = Angle(val, unit=u.hour)
-                else:
-                   val = Angle(val, unit=u.deg)
-                header_dict[keyword] = val
-
-    return header_dict
 
 def read_next_header_keyword(fh):
     """
@@ -205,11 +133,12 @@ def read_next_header_keyword(fh):
         if dtype == b'angle':
             val = struct.unpack('<d', fh.read(8))[0]
             val = fil_double_to_angle(val)
-            if keyword == 'src_raj':
+            if keyword == b'src_raj':
                 val = Angle(val, unit=u.hour)
             else:
                 val = Angle(val, unit=u.deg)
         return keyword, val, idx
+
 
 def is_filterbank(filename):
     """ Open file and confirm if it is a filterbank file or not. """
@@ -226,6 +155,7 @@ def is_filterbank(filename):
         except KeyError:
             is_fil = False
         return is_fil
+
 
 def read_header(filename, return_idxs=False):
     """ Read blimpy header and return a Python dictionary of key:value pairs
@@ -346,7 +276,7 @@ def to_sigproc_keyword(keyword, value=None):
         value_str (str): serialized string to write to file.
     """
 
-#    keyword = str(keyword)
+    keyword = bytes(keyword)
 
     if value is None:
         return np.int32(len(keyword)).tostring() + keyword
@@ -393,6 +323,7 @@ def generate_sigproc_header(f):
     header_string += to_sigproc_keyword(b'HEADER_END')
     return header_string
 
+
 def to_sigproc_angle(angle_val):
     """ Convert an astropy.Angle to the ridiculous sigproc angle format string. """
     x = str(angle_val)
@@ -415,11 +346,13 @@ def to_sigproc_angle(angle_val):
     num = str(d).zfill(2) + str(m).zfill(2) + str(s).zfill(2)+ '.' + str(ss).split(".")[-1]
     return np.float64(num).tostring()
 
+
 def calc_n_ints_in_file(filename):
     """ Calculate number of integrations in a given file """
     # Load binary data
     h = read_header(filename)
     n_bytes  = int(h[b'nbits'] / 8)
+
     n_chans = h[b'nchans']
     n_ifs   = h[b'nifs']
     idx_data = len_header(filename)
@@ -427,5 +360,10 @@ def calc_n_ints_in_file(filename):
     f.seek(idx_data)
     filesize = os.path.getsize(filename)
     n_bytes_data = filesize - idx_data
-    n_ints = int(n_bytes_data / (n_bytes * n_chans * n_ifs))
+
+    if h[b'nbits'] == 2:
+        n_ints = int(4 * n_bytes_data / (n_chans * n_ifs))
+    else:
+        n_ints = int(n_bytes_data / (n_bytes * n_chans * n_ifs))
+
     return n_ints

--- a/blimpy/waterfall.py
+++ b/blimpy/waterfall.py
@@ -94,8 +94,7 @@ MAX_BLOB_MB         = 1024                   # Max size of blob in MB
 class Waterfall(Filterbank):
     """ Class for loading and writing blimpy data (.fil, .h5) """
 
-    def __init__(self, filename=None, f_start=None, f_stop=None,t_start=None, t_stop=None, load_data=True, max_load=None, header_dict=None, data_array=None,
-                 max_data_array_size=None):
+    def __init__(self, filename=None, f_start=None, f_stop=None,t_start=None, t_stop=None, load_data=True, max_load=None, header_dict=None, data_array=None):
         """ Class for loading and plotting blimpy data.
 
         This class parses the blimpy file and stores the header and data
@@ -111,7 +110,7 @@ class Waterfall(Filterbank):
             t_start (int): start integration ID
             t_stop (int): stop integration ID
             load_data (bool): load data. If set to False, only header will be read.
-            max_load (bool): maximum data amount to load Default:1GB.
+            max_load (float): maximum data amount to load in GB. E.g. 0.1 is 100 MB
             header_dict (dict): Create blimpy from header dictionary + data array
             data_array (np.array): Create blimpy from header dict + data array
         """
@@ -122,7 +121,7 @@ class Waterfall(Filterbank):
             self.filename = filename
             self.ext = os.path.splitext(filename)[-1].lower()
             self.container = fw.open_file(filename, f_start=f_start, f_stop=f_stop, t_start=t_start, t_stop=t_stop,
-                                          load_data=load_data, max_load=max_load, max_data_array_size=max_data_array_size)
+                                          load_data=load_data, max_load=max_load)
             self.file_header = self.container.header
             self.header = self.file_header
             self.n_ints_in_file = self.container.n_ints_in_file

--- a/blimpy/waterfall.py
+++ b/blimpy/waterfall.py
@@ -94,7 +94,8 @@ MAX_BLOB_MB         = 1024                   # Max size of blob in MB
 class Waterfall(Filterbank):
     """ Class for loading and writing blimpy data (.fil, .h5) """
 
-    def __init__(self, filename=None, f_start=None, f_stop=None,t_start=None, t_stop=None, load_data=True, max_load=None, header_dict=None, data_array=None):
+    def __init__(self, filename=None, f_start=None, f_stop=None,t_start=None, t_stop=None, load_data=True, max_load=None, header_dict=None, data_array=None,
+                 max_data_array_size=None):
         """ Class for loading and plotting blimpy data.
 
         This class parses the blimpy file and stores the header and data
@@ -120,7 +121,8 @@ class Waterfall(Filterbank):
         if filename:
             self.filename = filename
             self.ext = filename.split(".")[-1].strip().lower()  #File extension
-            self.container = fw.open_file(filename, f_start=f_start, f_stop=f_stop,t_start=t_start, t_stop=t_stop,load_data=load_data,max_load=max_load)
+            self.container = fw.open_file(filename, f_start=f_start, f_stop=f_stop, t_start=t_start, t_stop=t_stop,
+                                          load_data=load_data, max_load=max_load, max_data_array_size=max_data_array_size)
             self.file_header = self.container.header
             self.header = self.file_header
             self.n_ints_in_file = self.container.n_ints_in_file

--- a/blimpy/waterfall.py
+++ b/blimpy/waterfall.py
@@ -120,7 +120,7 @@ class Waterfall(Filterbank):
 
         if filename:
             self.filename = filename
-            self.ext = filename.split(".")[-1].strip().lower()  #File extension
+            self.ext = os.path.splitext(filename)[-1].lower()
             self.container = fw.open_file(filename, f_start=f_start, f_stop=f_stop, t_start=t_start, t_stop=t_stop,
                                           load_data=load_data, max_load=max_load, max_data_array_size=max_data_array_size)
             self.file_header = self.container.header

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ setup.py -- setup script for use of packages.
 """
 from setuptools import setup, find_packages
 
-__version__ = '1.2.0'
+__version__ = '1.3.2'
 
 # create entry points
 # see http://astropy.readthedocs.org/en/latest/development/scripts.html

--- a/tests/test_dice.py
+++ b/tests/test_dice.py
@@ -1,0 +1,9 @@
+from blimpy import dice
+import pytest
+
+def test_dice():
+    with pytest.raises(SystemExit):
+        dice.cmd_tool()
+
+if __name__ == "__main__":
+    test_dice()

--- a/tests/test_file_wrapper.py
+++ b/tests/test_file_wrapper.py
@@ -1,0 +1,27 @@
+import blimpy as bl
+import pytest
+
+def test_read_fns():
+    """ These read functions are currently not implemented. """
+    a = bl.Waterfall('Voyager_data/Voyager1.single_coarse.fine_res.fil')
+    b = bl.Waterfall('Voyager_data/Voyager1.single_coarse.fine_res.h5')
+    with pytest.raises(NotImplementedError):
+        a.container.read_all()
+        a.container.read_row(0)
+        a.container.read_rows(0, 2)
+
+        b.container.read_all()
+        b.container.read_row(0)
+        b.container.read_rows(0, 2)
+
+def test_file_wrapper_open_file():
+    from blimpy.file_wrapper import open_file
+    open_file('Voyager_data/Voyager1.single_coarse.fine_res.h5')
+    open_file('Voyager_data/Voyager1.single_coarse.fine_res.fil')
+
+    with pytest.raises(NotImplementedError):
+        open_file('run_tests.sh')
+
+if __name__ == "__main__":
+    test_read_fns()
+    test_file_wrapper_open_file()

--- a/tests/test_filterbank_voyager.py
+++ b/tests/test_filterbank_voyager.py
@@ -1,5 +1,5 @@
 import blimpy as bl
-from blimpy import sigproc
+
 import numpy as np
 from pprint import pprint
 import pytest
@@ -52,23 +52,14 @@ def test_plotting_doesnt_cause_exceptions():
     b.plot_waterfall()
     b.plot_time_series()
 
-def test_sigproc_is_fil():
-    """ Check that the is_fil function works """
 
-    assert sigproc.is_filterbank('Voyager_data/Voyager1.single_coarse.fine_res.h5') is False
-    assert sigproc.is_filterbank('Voyager_data/Voyager1.single_coarse.fine_res.fil') is True
-
-def test_file_wrapper_open_file():
-    from blimpy.file_wrapper import open_file
-    open_file('Voyager_data/Voyager1.single_coarse.fine_res.h5')
-    open_file('Voyager_data/Voyager1.single_coarse.fine_res.fil')
-
-    with pytest.raises(NotImplementedError):
-        open_file('run_tests.sh')
+def test_cmdtool():
+    with pytest.raises(SystemExit):
+        bl.waterfall.cmd_tool()
 
 
 if __name__ == "__main__":
     compare_filterbank_fil_to_h5()
     test_plotting_doesnt_cause_exceptions()
-    test_sigproc_is_fil()
-    test_file_wrapper_open_file()
+
+    test_cmdtool()

--- a/tests/test_filterbank_voyager.py
+++ b/tests/test_filterbank_voyager.py
@@ -1,6 +1,8 @@
 import blimpy as bl
+from blimpy import sigproc
 import numpy as np
 from pprint import pprint
+import pytest
 
 def compare_filterbank_fil_to_h5():
     """ Load Voyager dataset and test that both fil and hdf5 readers return same headers and data """
@@ -50,6 +52,23 @@ def test_plotting_doesnt_cause_exceptions():
     b.plot_waterfall()
     b.plot_time_series()
 
+def test_sigproc_is_fil():
+    """ Check that the is_fil function works """
+
+    assert sigproc.is_filterbank('Voyager_data/Voyager1.single_coarse.fine_res.h5') is False
+    assert sigproc.is_filterbank('Voyager_data/Voyager1.single_coarse.fine_res.fil') is True
+
+def test_file_wrapper_open_file():
+    from blimpy.file_wrapper import open_file
+    open_file('Voyager_data/Voyager1.single_coarse.fine_res.h5')
+    open_file('Voyager_data/Voyager1.single_coarse.fine_res.fil')
+
+    with pytest.raises(NotImplementedError):
+        open_file('run_tests.sh')
+
+
 if __name__ == "__main__":
-    compare_filterbank_fil_to_h5()
-    test_plotting_doesnt_cause_exceptions()
+    #compare_filterbank_fil_to_h5()
+    #test_plotting_doesnt_cause_exceptions()
+    test_sigproc_is_fil()
+    test_file_wrapper_open_file()

--- a/tests/test_filterbank_voyager.py
+++ b/tests/test_filterbank_voyager.py
@@ -68,7 +68,7 @@ def test_file_wrapper_open_file():
 
 
 if __name__ == "__main__":
-    #compare_filterbank_fil_to_h5()
-    #test_plotting_doesnt_cause_exceptions()
+    compare_filterbank_fil_to_h5()
+    test_plotting_doesnt_cause_exceptions()
     test_sigproc_is_fil()
     test_file_wrapper_open_file()

--- a/tests/test_heavy.py
+++ b/tests/test_heavy.py
@@ -12,7 +12,7 @@ import pylab as plt
 
 def test_max_data_array_size():
     fw = bl.Waterfall('Voyager_data/Voyager1.single_coarse.fine_res.fil', max_data_array_size=1)
-    fw = bl.Waterfall('Voyager_data/Voyager1.single_coarse.fine_res.h5', max_data_array_size=1)
+    fw = bl.Waterfall('Voyager_data/Voyager1.single_coarse.fine_res.h5',  max_data_array_size=1)
 
 if __name__ == "__main__":
     test_max_data_array_size()

--- a/tests/test_heavy.py
+++ b/tests/test_heavy.py
@@ -1,0 +1,17 @@
+"""
+# test_voyager_data_load.py
+
+The hard-coded numbers in these tests can be found in the voyager_test_setup.ipynb
+
+"""
+
+import blimpy as bl
+import numpy as np
+import pylab as plt
+
+
+def test_max_data_array_size():
+    fw = bl.Waterfall('Voyager_data/Voyager1.single_coarse.fine_res.fil', max_data_array_size=1)
+
+if __name__ == "__main__":
+    test_max_data_array_size()

--- a/tests/test_heavy.py
+++ b/tests/test_heavy.py
@@ -12,6 +12,7 @@ import pylab as plt
 
 def test_max_data_array_size():
     fw = bl.Waterfall('Voyager_data/Voyager1.single_coarse.fine_res.fil', max_data_array_size=1)
+    fw = bl.Waterfall('Voyager_data/Voyager1.single_coarse.fine_res.h5', max_data_array_size=1)
 
 if __name__ == "__main__":
     test_max_data_array_size()

--- a/tests/test_heavy.py
+++ b/tests/test_heavy.py
@@ -11,8 +11,8 @@ import pylab as plt
 
 
 def test_max_data_array_size():
-    fw = bl.Waterfall('Voyager_data/Voyager1.single_coarse.fine_res.fil', max_data_array_size=1)
-    fw = bl.Waterfall('Voyager_data/Voyager1.single_coarse.fine_res.h5',  max_data_array_size=1)
+    fw = bl.Waterfall('Voyager_data/Voyager1.single_coarse.fine_res.fil', max_load=0.001)
+    fw = bl.Waterfall('Voyager_data/Voyager1.single_coarse.fine_res.h5',  max_load=0.001)
 
 if __name__ == "__main__":
     test_max_data_array_size()

--- a/tests/test_sigproc.py
+++ b/tests/test_sigproc.py
@@ -1,0 +1,51 @@
+from blimpy import sigproc
+import blimpy as bl
+import pytest
+import numpy as np
+import os
+
+def test_sigproc_is_fil():
+    """ Check that the is_fil function works """
+
+    assert sigproc.is_filterbank('Voyager_data/Voyager1.single_coarse.fine_res.h5') is False
+    assert sigproc.is_filterbank('Voyager_data/Voyager1.single_coarse.fine_res.fil') is True
+
+def test_sigproc_generate_headers():
+    """ Test if you can generate headers OK from files """
+    a = bl.Filterbank('Voyager_data/Voyager1.single_coarse.fine_res.h5')
+    b = bl.Filterbank('Voyager_data/Voyager1.single_coarse.fine_res.fil')
+    sigproc.generate_sigproc_header(a)
+    sigproc.generate_sigproc_header(b)
+
+def test_fil_write():
+    try:
+        a = bl.Filterbank('Voyager_data/Voyager1.single_coarse.fine_res.h5')
+        b = bl.Filterbank('Voyager_data/Voyager1.single_coarse.fine_res.fil')
+
+        a.write_to_filterbank('test.fil')
+        b.write_to_filterbank('test2.fil')
+
+        c = bl.Filterbank('test.fil')
+        d = bl.Filterbank('test2.fil')
+
+        for key in a.header.keys():
+            if key != b'DIMENSION_LABELS':
+                assert a.header[key] == c.header[key]
+                assert key in c.header.keys()
+                assert a.header[key] == d.header[key]
+                assert key in d.header.keys()
+
+        assert np.allclose(a.data, c.data)
+        assert np.allclose(a.data, d.data)
+    except AssertionError:
+        print(key, a.header[key], b.header[key], c.header[key], d.header[key])
+        raise
+
+    finally:
+        os.remove('test.fil')
+        os.remove('test2.fil')
+
+if __name__ == "__main__":
+    test_sigproc_is_fil()
+    test_sigproc_generate_headers()
+    test_fil_write()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ from blimpy import utils
 import numpy as np
 import pytest
 
+
 def test_utils():
     assert utils.db(100) == 20.0
     assert utils.lin(20)  == 100.0
@@ -27,6 +28,7 @@ def test_rebin():
     c = np.zeros([10, 10, 10])
     with pytest.raises(RuntimeError):
         utils.rebin(c, 2, 2)
+
 
 if __name__ == "__main__":
     test_utils()


### PR DESCRIPTION
Waterfall currently loads data for small files, and if file is larger than `max_data_array_size`  it will not load data. This change adds a new keyword so that `max_data_array_size` can be set manually at runtime. This change is backwards compatible -- exisitng scripts should not need updating.

This should also fix issue #39

Longer term, we may want to think about changing how Waterfall loads data -- should it default to not loading data? Is there a tidier way to handle `max_load` and `max_data_array_size` and `load_data` flags?
