### PR TITLE
Hdf5plugin dev

### DIFF
--- a/blimpy/waterfall.py
+++ b/blimpy/waterfall.py
@@ -29,29 +29,6 @@ from blimpy.filterbank import Filterbank
 from blimpy import file_wrapper as fw
 from blimpy.sigproc import *
 
-try:
-    import h5py
-    HAS_HDF5 = True
-except ImportError:
-    HAS_HDF5 = False
-
-try:
-    HAS_BITSHUFFLE = True
-    import bitshuffle.h5
-except ImportError:
-    HAS_BITSHUFFLE = False
-    pass
-
-#import pdb #pdb.set_trace()
-
-# Check if $DISPLAY is set (for handling plotting on remote machines with no X-forwarding)
-if 'DISPLAY' in os.environ.keys():
-    import pylab as plt
-else:
-    import matplotlib
-    matplotlib.use('Agg')
-    import pylab as plt
-
 
 #------
 # Logging set up
@@ -68,6 +45,36 @@ else:
     format = '%%(relativeCreated)5d (name)-15s %(levelname)-8s %(message)s'
 
 logging.basicConfig(format=format,stream=stream,level = level_log)
+
+
+try:
+    import h5py
+    HAS_HDF5 = True
+except ImportError:
+    HAS_HDF5 = False
+
+try:
+    HAS_BITSHUFFLE = True
+    import bitshuffle.h5
+except ImportError:
+    try:
+        import hdf5plugin
+        logger.warning('Could not import bitshuffle, using hdf5plugin failover. Write access disabled.')
+    except ImportError:
+        pass
+    HAS_BITSHUFFLE = False
+    pass
+
+#import pdb #pdb.set_trace()
+
+# Check if $DISPLAY is set (for handling plotting on remote machines with no X-forwarding)
+if 'DISPLAY' in os.environ.keys():
+    import pylab as plt
+else:
+    import matplotlib
+    matplotlib.use('Agg')
+    import pylab as plt
+
 
 
 ###

--- a/blimpy/waterfall.py
+++ b/blimpy/waterfall.py
@@ -48,12 +48,6 @@ logging.basicConfig(format=format,stream=stream,level = level_log)
 
 
 try:
-    import h5py
-    HAS_HDF5 = True
-except ImportError:
-    HAS_HDF5 = False
-
-try:
     HAS_BITSHUFFLE = True
     import bitshuffle.h5
 except ImportError:
@@ -64,6 +58,12 @@ except ImportError:
         pass
     HAS_BITSHUFFLE = False
     pass
+
+try:
+    import h5py
+    HAS_HDF5 = True
+except ImportError:
+    HAS_HDF5 = False
 
 #import pdb #pdb.set_trace()
 


### PR DESCRIPTION
In https://github.com/UCBerkeleySETI/turbo_seti/pull/17, @texadatcyl suggests using [hdf5plugin](https://github.com/silx-kit/hdf5plugin). This looks like a useful package---bitshuffle setup can be a pain---but as of right now (v1.4) it only supports read access.

The file layer stuff in turbo_seti should be upstream in blimpy, so adding the import here. A logger warning will be raised at import time if `hdf5plugin` is used as a failover in lieu of `bitshuffle.h5`.

While the bitshuffle issue is upstream (a combo of unusual paths for hdf5 libraries in Ubuntu, h5py and bitshuffle dependencies), this should give a different path to getting read support for collaborators.