### PR TITLE
Update guppi.py API to use generator method

### DIFF
--- a/docs/blimpy.calib_utils.rst
+++ b/docs/blimpy.calib_utils.rst
@@ -1,11 +1,6 @@
 blimpy.calib\_utils package
 ===========================
 
-.. automodule:: blimpy.calib_utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 Submodules
 ----------
 
@@ -34,3 +29,10 @@ blimpy.calib\_utils.stokescal module
     :show-inheritance:
 
 
+Module contents
+---------------
+
+.. automodule:: blimpy.calib_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/blimpy.rst
+++ b/docs/blimpy.rst
@@ -1,11 +1,6 @@
 blimpy package
 ==============
 
-.. automodule:: blimpy
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 Subpackages
 -----------
 
@@ -105,3 +100,10 @@ blimpy.waterfall module
     :show-inheritance:
 
 
+Module contents
+---------------
+
+.. automodule:: blimpy
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/writing_docs.rst
+++ b/docs/writing_docs.rst
@@ -30,6 +30,11 @@ After ``sphinx`` is installed, you can preview your changes by running ``make ht
 The rendered html files will be stored in ``docs/_build/html``. The actual site will look exactly like the rendered
 files when built.
 
+Automatic Documentation
+-----------------------
+You can run ``sphinx-apidoc -o . ../blimpy/ -f`` in ``blimpy/docs`` to generate autodoc pages from all the python modules in blimpy.
+Make sure to run this command every time a new file is added to blimpy.
+
 Updating the Site
 -----------------
 The blimpy Github repo is connected to `readthedocs.org` with a webhook. `readthedocs` will automatically update the site


### PR DESCRIPTION
#29 
I renamed the original`read_next_data_block_int8` to `generator_read_next_data_block_int8`, and added a new version of `read_next_data_block_int8` which uses the generator method to get data.
The new`read_next_data_block_int8` now prints a line saying that the data file is depleted and returns none instead of throwing an `EndOfFileError`.