### PR TITLE
86 last guppi block not read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+build/
+dist/
+.eggs/
+blimpy.egg-info/
+*.pyc
+*.swp

--- a/blimpy/utils.py
+++ b/blimpy/utils.py
@@ -80,8 +80,8 @@ def unpack_complex64(data, nbit):
     data = unpack(data,nbit)
     return data.astype(np.float32).view(np.complex64)
 
-def unpack_1(data):
-    """ Promote 1-bit unisgned data into np.complex64 data.
+def unpack_1to8(data):
+    """ Promote 1-bit unsigned data into np.int8
 
     Args:
         data: Numpy array with dtype == uint8

--- a/blimpy/utils.py
+++ b/blimpy/utils.py
@@ -154,7 +154,7 @@ def unpack_4to8(data):
         # Note: This technique assumes LSB-first ordering
     """
 
-    tmpdata = data.view(uint8).astype(np.int16)  # np.empty(upshape, dtype=np.int16)
+    tmpdata = data.view(np.uint8).astype(np.int16)  # np.empty(upshape, dtype=np.int16)
     tmpdata = (tmpdata | (tmpdata << 4)) & 0x0F0F
     # tmpdata = tmpdata << 4 # Shift into high bits to avoid needing to sign extend
     updata = tmpdata.byteswap()


### PR DESCRIPTION
This addresses issue #86, where the last guppi block isn't being read.

It also *should* address `NPOL=4`, as stated in (doc/RAW-File-Format.md)[https://github.com/UCBerkeleySETI/breakthrough/blob/master/doc/RAW-File-Format.md#well-known-keywords], but it's only been tested against `NPOL=4` files, so I'm not sure if it handles `NPOL=1` or `NPOL=2` files correctly.

The intended processing flow should go like this:
```
from blimpy.guppi import GuppiRaw, EndOfFileError
r = GuppiRaw(filename)
while(True):
    try:
        header,data = r.read_next_data_block()
    except EndOfFileError as e:
        break
    # handle data and header as desired.
```

Other flows might not be handled correctly, so let me know if that's not what you're going for.  Also, this commit likely breaks the `get_data()` method that uses `self._d_x` and `self._d_y` internally.