### PR TITLE
update `read_next_data_block` to call int8 version

### DIFF
--- a/blimpy/guppi.py
+++ b/blimpy/guppi.py
@@ -8,13 +8,14 @@ The guppi raw format consists of a FITS-like header, followed by a block of data
 and repeated over and over until the end of the file.
 """
 
-import os
-import sys
-
 import numpy as np
+import os
+import time
+from pprint import pprint
 from astropy.coordinates import Angle
 
 from .utils import unpack, rebin
+import sys
 
 PYTHON3 = sys.version_info >= (3, 0)
 
@@ -186,7 +187,7 @@ class GuppiRaw(object):
         Returns:
             dshape (tuple) - shape of the corresponding data block
         """
-        if (header is None):
+        if(header is None):
             header, data_idx = self.read_header()
         n_chan = int(header['OBSNCHAN'])
         n_pol = int(header['NPOL'])
@@ -368,6 +369,8 @@ class GuppiRaw(object):
         print("STD: %2.3f" % data.std())
         print("MAX: %2.3f" % data.max())
         print("MIN: %2.3f" % data.min())
+
+        import pylab as plt
 
     def plot_histogram(self, filename=None):
         """ Plot a histogram of data values """

--- a/blimpy/guppi.py
+++ b/blimpy/guppi.py
@@ -233,7 +233,7 @@ class GuppiRaw(object):
             self.data_gen = None
             return None, None, None
         self._d_x, self._d_y = data_x, data_y
-        return header, self._d_x, self._d_y
+        return header, np.copy(self._d_x), np.copy(self._d_y)
 
     def generator_read_next_data_block_int8(self):
         """ Read the next block of data and its header
@@ -242,7 +242,6 @@ class GuppiRaw(object):
             header (dict): dictionary of header metadata
             data (np.array): Numpy array of data, converted into to complex64.
 
-        TODO: deprecate?
         """
         header, data_idx = self.read_header()
         self.file_obj.seek(data_idx)
@@ -276,6 +275,7 @@ class GuppiRaw(object):
         Returns: (header, data)
             header (dict): dictionary of header metadata
             data (np.array): Numpy array of data, converted into to complex64.
+        TODO: Deprecate?
         """
         header, data_idx = self.read_header()
         self.file_obj.seek(data_idx)


### PR DESCRIPTION
`read_next_data_block` now uses `read_next_data_block_int8` as a subroutine. Since they basically do the same thing, it makes sense to replace redundant code with a written function.
This helps prevent bugs like #86 