### PR TITLE
Cast plot_data to `uint16` when nbit=8

### DIFF
--- a/blimpy/filterbank.py
+++ b/blimpy/filterbank.py
@@ -501,6 +501,9 @@ class Filterbank(object):
             plot_f    = self.freqs[i1:i0 + 1]
             plot_data = np.squeeze(self.data[t_start:t_stop, ..., i1:i0 + 1])
 
+        if plot_data.dtype == 'uint8':
+            plot_data = plot_data.astype('uint16')
+
         return plot_f, plot_data
 
     def _calc_extent(self,plot_f=None,plot_t=None,MJD_time=False,inv_t=False):

--- a/blimpy/waterfall.py
+++ b/blimpy/waterfall.py
@@ -96,7 +96,8 @@ MAX_BLOB_MB         = 1024                   # Max size of blob in MB
 class Waterfall(Filterbank):
     """ Class for loading and writing blimpy data (.fil, .h5) """
 
-    def __init__(self, filename=None, f_start=None, f_stop=None,t_start=None, t_stop=None, load_data=True, max_load=1., header_dict=None, data_array=None):
+    def __init__(self, filename=None, f_start=None, f_stop=None, t_start=None, t_stop=None,
+                 load_data=True, max_load=1., header_dict=None, data_array=None):
         """ Class for loading and plotting blimpy data.
 
         This class parses the blimpy file and stores the header and data


### PR DESCRIPTION
Deals with #65 where matplotlib breaks while trying to plot `uint8` data. Casting to `uint16` should solve the issue. I will do more testing on this once I get access to more filterbank data.