### PR TITLE
fix plot-spectrum

### DIFF
--- a/blimpy/guppi.py
+++ b/blimpy/guppi.py
@@ -395,7 +395,7 @@ class GuppiRaw(object):
         # Rebin to max number of points
         dec_fac_x = 1
         if d_xx_fft.shape[0] > MAX_PLT_POINTS:
-            dec_fac_x = d_xx_fft.shape[0] / MAX_PLT_POINTS
+            dec_fac_x = int(d_xx_fft.shape[0] / MAX_PLT_POINTS)
 
         d_xx_fft = rebin(d_xx_fft, dec_fac_x)
 


### PR DESCRIPTION
Fix small error with guppi, numpy complained about `dec_fac_x` not being an integer as it was being passed to `rebin`.