### PR TITLE
Issue #116

### DIFF
--- a/blimpy/io/hdf_writer.py
+++ b/blimpy/io/hdf_writer.py
@@ -40,7 +40,12 @@ def __write_to_hdf5_heavy(wf, filename_out, f_scrunch=None, *args, **kwargs):
 
     #Note that a chunk is not a blob!!
     #chunk_dim = wf._get_chunk_dimensions() <-- seems intended for raw to fil
-    chunk_dim = (1, 1, wf.selection_shape[-1])
+    #And, chunk dimensions should not exceed the Waterfall selection shape dimensions.
+    chunk_list = list(wf._get_chunk_dimensions())
+    for ix in range(0, len(chunk_list)):
+        if chunk_list[ix] > wf.selection_shape[ix]:
+            chunk_list[ix] = wf.selection_shape[ix]
+    chunk_dim = tuple(chunk_list)
     blob_dim  = wf._get_blob_dimensions(chunk_dim)
     n_blobs   = wf.container.calc_n_blobs(blob_dim)
 

--- a/blimpy/io/hdf_writer.py
+++ b/blimpy/io/hdf_writer.py
@@ -39,7 +39,8 @@ def __write_to_hdf5_heavy(wf, filename_out, f_scrunch=None, *args, **kwargs):
     block_size = 0
 
     #Note that a chunk is not a blob!!
-    chunk_dim = wf._get_chunk_dimensions()
+    #chunk_dim = wf._get_chunk_dimensions() <-- seems intended for raw to fil
+    chunk_dim = (1, 1, wf.selection_shape[-1])
     blob_dim  = wf._get_blob_dimensions(chunk_dim)
     n_blobs   = wf.container.calc_n_blobs(blob_dim)
 


### PR DESCRIPTION
hdf_writer.py/__write_to_hdf5_heavy(): chunk_dim calculation:
- Waterfall._get_chunk_dimensions() seems to be intended for converting raw guppi files to Filterbank format.
- It seems to me that (1, 1, {Number of Channels}) is a better choice when writing an h5.