### PR TITLE
Fix plot spectrum min max when zeros are present

### DIFF
--- a/blimpy/plotting/plot_spectrum_min_max.py
+++ b/blimpy/plotting/plot_spectrum_min_max.py
@@ -66,9 +66,9 @@ def plot_spectrum_min_max(wf, t=0, f_start=None, f_stop=None, logged=False, if_i
     plt.xlim(plot_f[0], plot_f[-1])
     if logged:
         try:
-            plt.ylim(db(fig_min), db(fig_max))
+            plt.ylim(db(fig_min) - 1, db(fig_max) + 1)
         except ValueError:
             if fig_max != 0:
-                plt.ylim(db(plot_data[0][plot_data[0] != 0].min()), db(fig_max))
+                plt.ylim(db(plot_data[0][plot_data[0] != 0].min()) - 1, db(fig_max) + 1)
             else:
                 plt.ylim(-10, 20)

--- a/blimpy/plotting/plot_spectrum_min_max.py
+++ b/blimpy/plotting/plot_spectrum_min_max.py
@@ -23,9 +23,6 @@ def plot_spectrum_min_max(wf, t=0, f_start=None, f_stop=None, logged=False, if_i
         db_plot_data = db(plot_data[0])
         fig_max = np.nanmax(db_plot_data[db_plot_data != np.inf])
         fig_min = np.nanmin(db_plot_data[db_plot_data != -np.inf])
-        print(db_plot_data)
-        print(fig_min)
-        print(fig_max)
     else:
         fig_max = plot_data[0].max()
         fig_min = plot_data[0].min()

--- a/blimpy/plotting/plot_spectrum_min_max.py
+++ b/blimpy/plotting/plot_spectrum_min_max.py
@@ -19,8 +19,13 @@ def plot_spectrum_min_max(wf, t=0, f_start=None, f_stop=None, logged=False, if_i
         plot_data = plot_data[..., ::-1]  # Reverse data
         plot_f = plot_f[::-1]
 
-    fig_max = plot_data[0].max()
-    fig_min = plot_data[0].min()
+    if logged:
+        db_plot_data = db(plot_data[0])
+        fig_max = np.nanmax(db_plot_data)
+        fig_min = np.nanmin(db_plot_data)
+    else:
+        fig_max = plot_data[0].max()
+        fig_min = plot_data[0].min()
 
     print("averaging along time axis...")
 
@@ -66,9 +71,6 @@ def plot_spectrum_min_max(wf, t=0, f_start=None, f_stop=None, logged=False, if_i
     plt.xlim(plot_f[0], plot_f[-1])
     if logged:
         try:
-            plt.ylim(db(fig_min) - 1, db(fig_max) + 1)
+            plt.ylim(fig_min - 1, fig_max + 1)
         except ValueError:
-            if fig_max != 0:
-                plt.ylim(db(plot_data[0][plot_data[0] != 0].min()) - 1, db(fig_max) + 1)
-            else:
-                plt.ylim(-10, 20)
+            plt.ylim(-10, 20)

--- a/blimpy/plotting/plot_spectrum_min_max.py
+++ b/blimpy/plotting/plot_spectrum_min_max.py
@@ -21,8 +21,11 @@ def plot_spectrum_min_max(wf, t=0, f_start=None, f_stop=None, logged=False, if_i
 
     if logged:
         db_plot_data = db(plot_data[0])
-        fig_max = np.nanmax(db_plot_data)
-        fig_min = np.nanmin(db_plot_data)
+        fig_max = np.nanmax(db_plot_data[db_plot_data != np.inf])
+        fig_min = np.nanmin(db_plot_data[db_plot_data != -np.inf])
+        print(db_plot_data)
+        print(fig_min)
+        print(fig_max)
     else:
         fig_max = plot_data[0].max()
         fig_min = plot_data[0].min()

--- a/blimpy/plotting/plot_spectrum_min_max.py
+++ b/blimpy/plotting/plot_spectrum_min_max.py
@@ -65,4 +65,10 @@ def plot_spectrum_min_max(wf, t=0, f_start=None, f_stop=None, logged=False, if_i
 
     plt.xlim(plot_f[0], plot_f[-1])
     if logged:
-        plt.ylim(db(fig_min), db(fig_max))
+        try:
+            plt.ylim(db(fig_min), db(fig_max))
+        except ValueError:
+            if fig_max != 0:
+                plt.ylim(db(plot_data[0][plot_data[0] != 0].min()), db(fig_max))
+            else:
+                plt.ylim(-10, 20)

--- a/blimpy/plotting/plot_time_series.py
+++ b/blimpy/plotting/plot_time_series.py
@@ -14,15 +14,16 @@ def plot_time_series(wf, f_start=None, f_stop=None, if_id=0, logged=True, orient
 
     ax = plt.gca()
     plot_f, plot_data = wf.grab_data(f_start, f_stop, if_id)
-
-    if logged and wf.header['nbits'] >= 8:
-        plot_data = db(plot_data)
-    print(plot_data)
+    
     # Since the data has been squeezed, the axis for time goes away if only one bin, causing a bug with axis=1
     if len(plot_data.shape) > 1:
         plot_data = np.nanmean(plot_data, axis=1)
     else:
         plot_data = np.nanmean(plot_data)
+    print(plot_data)
+
+    if logged and wf.header['nbits'] >= 8:
+        plot_data = db(plot_data)
     print(plot_data)
 
     # Make proper time axis for plotting (but only for plotting!). Note that this makes the values inclusive.

--- a/blimpy/plotting/plot_time_series.py
+++ b/blimpy/plotting/plot_time_series.py
@@ -17,12 +17,13 @@ def plot_time_series(wf, f_start=None, f_stop=None, if_id=0, logged=True, orient
 
     if logged and wf.header['nbits'] >= 8:
         plot_data = db(plot_data)
-
+    print(plot_data)
     # Since the data has been squeezed, the axis for time goes away if only one bin, causing a bug with axis=1
     if len(plot_data.shape) > 1:
-        plot_data = plot_data.mean(axis=1)
+        plot_data = np.nanmean(plot_data, axis=1)
     else:
-        plot_data = plot_data.mean()
+        plot_data = np.nanmean(plot_data)
+    print(plot_data)
 
     # Make proper time axis for plotting (but only for plotting!). Note that this makes the values inclusive.
     extent = calc_extent(wf, plot_f=plot_f, plot_t=wf.timestamps, MJD_time=MJD_time)


### PR DESCRIPTION
Set the left side of ylim to the db of the smallest nonzero value in the data when the smallest is 0. Using 0 makes pyplot throw a ValueError complaining that the left side of ylim is set to -inf.