### PR TITLE
Make the reasons for failure in grab_data() more clear

### DIFF
--- a/blimpy/waterfall.py
+++ b/blimpy/waterfall.py
@@ -283,23 +283,32 @@ class Waterfall(object):
             (freqs, data) (np.arrays): frequency axis in MHz and data subset
         """
 
-        self.freqs = self.container.populate_freqs()
-        self.timestamps = self.container.populate_timestamps()
+        try:
+            self.freqs = self.container.populate_freqs()
+        except:
+            raise Exception("Waterfall.grab_data: Cannot allocate frequency array")
+        try:
+            self.timestamps = self.container.populate_timestamps()
+        except:
+            raise Exception("Waterfall.grab_data: Cannot allocate timestamps array")
 
         if f_start is None:
             f_start = self.freqs[0]
         if f_stop is None:
             f_stop = self.freqs[-1]
 
-        i0 = np.argmin(np.abs(self.freqs - f_start))
-        i1 = np.argmin(np.abs(self.freqs - f_stop))
+        try:
+            i0 = np.argmin(np.abs(self.freqs - f_start))
+            i1 = np.argmin(np.abs(self.freqs - f_stop))
 
-        if i0 < i1:
-            plot_f    = self.freqs[i0:i1 + 1]
-            plot_data = np.squeeze(self.data[t_start:t_stop, ..., i0:i1 + 1])
-        else:
-            plot_f    = self.freqs[i1:i0 + 1]
-            plot_data = np.squeeze(self.data[t_start:t_stop, ..., i1:i0 + 1])
+            if i0 < i1:
+                plot_f    = self.freqs[i0:i1 + 1]
+                plot_data = np.squeeze(self.data[t_start:t_stop, ..., i0:i1 + 1])
+            else:
+                plot_f    = self.freqs[i1:i0 + 1]
+                plot_data = np.squeeze(self.data[t_start:t_stop, ..., i1:i0 + 1])
+        except:
+            raise Exception("Waterfall.grab_data: Too much data requested")
 
         return plot_f, plot_data
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.d', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
There are 3 points where a memory allocation could fail with large files:
- Allocating the frequency array.
- Allocating the timestamp array.
- Allocating the data array.

The proposed changes to grab_data() would provide raised exceptions with messages specific to the cause of the exception rather than "IndexError: too many indices for array".

By the way, is the timestamp array necessary since it is not used by grab_data()?