### PR TITLE
Support for data with multiple IFs / polarizations

### DIFF
--- a/blimpy/io/sigproc.py
+++ b/blimpy/io/sigproc.py
@@ -76,18 +76,19 @@ def len_header(filename):
     Returns:
         idx_end (int): length of header, in bytes
     """
+    GULP = 4096
     with open(filename, 'rb') as f:
         header_sub_count = 0
         eoh_found = False
         while not eoh_found:
-            header_sub = f.read(512)
+            header_sub = f.read(GULP)
             header_sub_count += 1
             if b'HEADER_END' in header_sub:
                 idx_end = header_sub.index(b'HEADER_END') + len(b'HEADER_END')
                 eoh_found = True
                 break
 
-        idx_end = (header_sub_count -1) * 512 + idx_end
+        idx_end = (header_sub_count -1) * GULP + idx_end
     return idx_end
 
 

--- a/blimpy/waterfall.py
+++ b/blimpy/waterfall.py
@@ -307,10 +307,10 @@ class Waterfall(object):
 
             if i0 < i1:
                 plot_f    = self.freqs[i0:i1 + 1]
-                plot_data = np.squeeze(self.data[t_start:t_stop, ..., i0:i1 + 1])
+                plot_data = np.squeeze(self.data[t_start:t_stop, if_id, i0:i1 + 1])
             else:
                 plot_f    = self.freqs[i1:i0 + 1]
-                plot_data = np.squeeze(self.data[t_start:t_stop, ..., i1:i0 + 1])
+                plot_data = np.squeeze(self.data[t_start:t_stop, if_id, i1:i0 + 1])
         except:
             raise Exception("Waterfall.grab_data: Too much data requested")
 


### PR DESCRIPTION
Two minor commits to 

a) avoid a bug with reading sigproc headers that are longer than 512B
b) add support to plot data with multiple IFs (e.g. polarizations) by using `if_id` argument