### PR TITLE
Fixed issue #208

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -3,6 +3,7 @@ This file is a version history of turbo_seti amendments, beginning with version 
 <br>
 |    Date    | Version | Contents |
 | :--: | :--: | :-- |
+| 2021-06-12 | 2.0.14 | Fix issue #208 - Miscalculated max_data_array_size available RAM < 1 GB  |
 | 2021-06-10 | 2.0.13 | Fix issue #205 - Define MeerKAT in the list of observatories |
 | | | Fix issue #207 guppi.py generate_filterban_header()
 | 2021-05-29 | 2.0.12 | Fix issue #203 - calc_n_coarse_chan default to 1 |

--- a/blimpy/io/base_reader.py
+++ b/blimpy/io/base_reader.py
@@ -39,7 +39,8 @@ class Reader(object):
             self.max_data_array_size = self.available_memory - GIGA
         else:
             self.max_data_array_size = self.available_memory
-            logger.warning("Very low on memory, only {} available for use.".format(self.available_memory))
+            logger.warning("Very low on memory, only {:.2f} MB available for use."
+                           .format(float(self.available_memory) / 1e6))
         logger.debug("Reader __init__ max_data_array_size={}".format(self.max_data_array_size))
 
     def _setup_selection_range(self, f_start=None, f_stop=None, t_start=None, t_stop=None, init=False):

--- a/blimpy/io/base_reader.py
+++ b/blimpy/io/base_reader.py
@@ -34,7 +34,13 @@ class Reader(object):
 
         # Calculate the max data array size from available memory
         self.available_memory = psutil.virtual_memory().available
-        self.max_data_array_size = self.available_memory - GIGA
+        logger.debug("Reader __init__ available_memory={}".format(self.available_memory))
+        if self.available_memory >= GIGA:
+            self.max_data_array_size = self.available_memory - GIGA
+        else:
+            self.max_data_array_size = self.available_memory
+            logger.warning("Very low on memory, only {} available for use.".format(self.available_memory))
+        logger.debug("Reader __init__ max_data_array_size={}".format(self.max_data_array_size))
 
     def _setup_selection_range(self, f_start=None, f_stop=None, t_start=None, t_stop=None, init=False):
         """Making sure the selection if time and frequency are within the file limits.

--- a/blimpy/io/base_reader.py
+++ b/blimpy/io/base_reader.py
@@ -35,7 +35,7 @@ class Reader(object):
         # Calculate the max data array size from available memory
         self.available_memory = psutil.virtual_memory().available
         logger.debug("Reader __init__ available_memory={}".format(self.available_memory))
-        if self.available_memory >= GIGA:
+        if self.available_memory > GIGA:
             self.max_data_array_size = self.available_memory - GIGA
         else:
             self.max_data_array_size = self.available_memory

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ setup.py -- setup script for use of packages.
 """
 from setuptools import setup, find_packages
 
-__version__ = '2.0.13'
+__version__ = '2.0.14'
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
The io/base_reader.py Reader class \_\_init\_\_ function miscalculated the max_data_array_size when available RAM was < 1 GB.