### PR TITLE
Fix issue #212

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -3,6 +3,7 @@ This file is a version history of turbo_seti amendments, beginning with version 
 <br>
 |    Date    | Version | Contents |
 | :--: | :--: | :-- |
+| 2021-07-17 | 2.0.18 | Get rid of numpy "RuntimeWarning: Mean of empty slice" messages (Issue #212).  |
 | 2021-07-13 | 2.0.17 | New utility: stax.  |
 | 2021-07-08 | 2.0.16 | Increase test coverage of calc_n_coarse_chan().  |
 | | | Improve messaging when calc_n_coarse_chan() emits warnings. |

--- a/blimpy/waterfall.py
+++ b/blimpy/waterfall.py
@@ -347,15 +347,20 @@ class Waterfall():
         n_coarse_chan = int(n_coarse_chan)
 
         n_chan = self.data.shape[-1]
-        n_chan_per_coarse = int(n_chan / n_coarse_chan)
+        n_chan_per_coarse = int(n_chan / n_coarse_chan) # ratio of fine channels to coarse channels
 
         mid_chan = int(n_chan_per_coarse / 2)
 
-        # YANKED 2021-03-05: @jit(nopython=True, fastmath=True, cache=True)
         def parse(data, n_coarse_chan, n_chan_per_coarse, mid_chan):
             for ii in range(n_coarse_chan):
                 ss = ii*n_chan_per_coarse
-                data[..., ss+mid_chan] = np.median(data[..., ss+mid_chan+5:ss+mid_chan+10])
+                w_slice = data[..., ss+mid_chan+5:ss+mid_chan+10]
+                chtest = w_slice.shape[-1]
+                # If we are nearing the end of the fine channel frequency array,
+                # do not do anymore.  See issue #212.
+                if chtest < 5:
+                    break
+                data[..., ss+mid_chan] = np.median(w_slice)
         
         parse(self.data, n_coarse_chan, n_chan_per_coarse, mid_chan)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ setup.py -- setup script for use of packages.
 """
 from setuptools import setup, find_packages
 
-__version__ = '2.0.17.2'
+__version__ = '2.0.18'
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
Waterfall.blank_dc() caused numpy "RuntimeWarning: Mean of empty slice" when the ratio between the number of fine channels to the number of coarse channels was < 5.  This is a boundary case.