### PR TITLE
Fix issues with stix and stax.

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -3,6 +3,7 @@ This file is a version history of blimpy amendments, beginning with version 2.0.
 <br>
 |    Date    | Version | Contents |
 | :--: | :--: | :-- |
+| 2021-08-18 | 2.0.27.1 | Fix problems with stix and stax.  |
 | 2021-08-17 | 2.0.27 | Fix problems in various regression tests.  |
 | 2021-08-17 | 2.0.26 | Implement requirements_test.txt (Issue #234).  |
 | 2021-08-16 | 2.0.25 | Try to remove HDF5 files that cannot be fully written due to an exception (Issue #232).  |

--- a/blimpy/stax.py
+++ b/blimpy/stax.py
@@ -264,7 +264,7 @@ def make_waterfall_plots(file_list, plot_dir, f_start=None, f_stop=None, **kwarg
     plt.close("all")
 
 
-def cmd_line(args=None):
+def cmd_tool(args=None):
     r"""Coomand line parser"""
     parser = ArgumentParser(description='Make waterfall plots from a set of files, viewed from top to bottom.')
     parser.add_argument('file_list', type=str, nargs='+', help='List of files to plot')
@@ -288,4 +288,4 @@ def cmd_line(args=None):
 
 
 if __name__ == "__main__":
-    cmd_line()
+    cmd_tool()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ setup.py -- setup script for use of packages.
 """
 from setuptools import setup, find_packages
 
-__version__ = '2.0.28'
+__version__ = '2.0.27.1'
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ entry_points = {
         'bldice = blimpy.dice:cmd_tool',
         'calcload = blimpy.calcload:cmd_tool',
         'rawhdr = blimpy.rawhdr:cmd_tool',
-        'stax = blimpy.stax:cmd_line'
+        'stax = blimpy.stax:cmd_tool',
+        'stix = blimpy.stix:cmd_tool',
      ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ setup.py -- setup script for use of packages.
 """
 from setuptools import setup, find_packages
 
-__version__ = '2.0.27'
+__version__ = '2.0.28'
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/tests/test_stax.py
+++ b/tests/test_stax.py
@@ -1,14 +1,14 @@
 from os.path import dirname
-from blimpy.stax import cmd_line
+from blimpy.stax import cmd_tool
 from tests.data import voyager_fil, voyager_h5
 
 
 def test_stax():
     dir = dirname(voyager_h5)
     args = [voyager_fil, voyager_h5, "-plot_dir", dir]
-    cmd_line(args)
+    cmd_tool(args)
     args = [voyager_fil, voyager_h5, "-plot_dir", dir, "-f_start", "8419", "-f_stop", "8420"]
-    cmd_line(args)
+    cmd_tool(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. Lost executable ```stix```.  recovered.
2. The entry point name for ```stax`` was corrected to be consistent with the rest of blimpy.