### PR TITLE
New blimpy utility: peek

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -3,6 +3,7 @@ This file is a version history of blimpy amendments, beginning with version 2.0.
 <br>
 |    Date    | Version | Contents |
 | :--: | :--: | :-- |
+| 2021-11-10 | 2.0.31 | New utility: peek.  |
 | 2021-10-03 | 2.0.30 | Fix issue #243.  |
 | 2021-08-18 | 2.0.29 | Clean up messages when writing files (Issue #241).  |
 | 2021-08-18 | 2.0.28 | Fix utility stax difficulties with the time-axis (Issue #238).  |

--- a/blimpy/peek.py
+++ b/blimpy/peek.py
@@ -1,0 +1,58 @@
+"""
+Simple script for quickly peeking at the data matrix.
+"""
+
+import sys
+from argparse import ArgumentParser
+
+from blimpy import Waterfall
+
+
+def oops(msg):
+    print("\n*** OOPS, {} !!!".format(msg))
+    sys.exit(86)
+
+
+def cmd_tool(args=None):
+    """ Command line utility for peeking at the data matrix.
+    """
+
+    parser = ArgumentParser(description="Command line utility for peeking at a .fil or .h5 file")
+    parser.add_argument("filepath_in", type=str, help="Path of input .fil or .h5 file")
+    parser.add_argument("-i", "--start_tint", dest="start_tint", type=int, default=0,
+                        help="Starting integration index relative to 0.  Default: 0")
+    parser.add_argument("-Z", "--if", dest="the_IF", type=int, default=0,
+                        help="Starting IF index relative to 0.  Default: 0")
+    parser.add_argument("-c", "--start_fchan", dest="start_fchan", type=int, default=0,
+                        help="Starting fine channel index relative to 0.  Default: 0")
+
+
+    if args is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(args)
+
+    wf = Waterfall(args.filepath_in)
+
+    if args.start_tint < 0 or args.start_tint > (wf.n_ints_in_file - 2):
+        oops("--start_tint is not a valid time integration index")
+    if args.the_IF < 0:
+        oops("--if is not a valid IF index")
+    if args.start_fchan < 0 or args.start_fchan > (wf.header["nchans"] - 3):
+        oops("--start_fchan is not a valid fine channel index")
+
+    print("Fine channel frequency columns     go this way ------->")
+    print("Integration_{}:                     {}   {}   {}"
+          .format(args.start_tint,
+                  wf.data[args.start_tint, args.the_IF, args.start_fchan],
+                  wf.data[args.start_tint, args.the_IF, args.start_fchan + 1],
+                  wf.data[args.start_tint, args.the_IF, args.start_fchan + 2]))
+    print("Integration_{}:                     {}   {}   {}"
+          .format(args.start_tint + 1,
+                  wf.data[args.start_tint + 1, args.the_IF, args.start_fchan],
+                  wf.data[args.start_tint + 1, args.the_IF, args.start_fchan + 1],
+                  wf.data[args.start_tint + 1, args.the_IF, args.start_fchan + 2]))
+
+
+if __name__ == "__main__":
+    cmd_tool()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ setup.py -- setup script for use of packages.
 """
 from setuptools import setup, find_packages
 
-__version__ = '2.0.30'
+__version__ = '2.0.31'
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -24,6 +24,7 @@ entry_points = {
         'rawhdr = blimpy.rawhdr:cmd_tool',
         'stax = blimpy.stax:cmd_tool',
         'stix = blimpy.stix:cmd_tool',
+        'peek = blimpy.peek:cmd_tool',
      ]
 }
 


### PR DESCRIPTION
```
usage: peek [-h] [-i START_TINT] [-Z THE_IF] [-c START_FCHAN] filepath_in

Command line utility for peeking at a .fil or .h5 file

positional arguments:
  filepath_in           Path of input .fil or .h5 file

optional arguments:
  -h, --help            show this help message and exit
  -i START_TINT, --start_tint START_TINT
                        Starting integration index relative to 0. Default: 0
  -Z THE_IF, --if THE_IF
                        Starting IF index relative to 0. Default: 0
  -c START_FCHAN, --start_fchan START_FCHAN
                        Starting fine channel index relative to 0. Default: 0
```