### PR TITLE
Address enhancement #249 (h5diag) plus surprises

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -3,6 +3,7 @@ This file is a version history of blimpy amendments, beginning with version 2.0.
 <br>
 |    Date    | Version | Contents |
 | :--: | :--: | :-- |
+| 2022-01-18 | 2.0.33 | Support rawspec 3.0 FBH5 format reporting (issue #249).  |
 | 2021-11-17 | 2.0.32 | New utility: srcname (issue #246).  |
 | 2021-11-10 | 2.0.31 | New utility: peek.  |
 | 2021-10-03 | 2.0.30 | Fix issue #243.  |

--- a/blimpy/h5diag.py
+++ b/blimpy/h5diag.py
@@ -36,10 +36,17 @@ def read_header(h5):
 
 def examine(filename):
     r""" Diagnose the given HDF5 file"""
-    h5 = h5py.File(filename, mode="r")
-    examine_h5(h5)
-    print("h5diag: header:", read_header(h5))
-    print("h5diag: data shape:", h5["data"].shape)
+    h5file = h5py.File(filename, mode="r")
+    version = examine_h5(h5file)
+    print("h5diag: VERSION attribute:", version)
+    print("h5diag: header:", read_header(h5file))
+    print("h5diag: data shape:", h5file["data"].shape)
+    if version >= 1.999:
+		print("Rawspec version:", h5file.attrs["VERSION_RAWSPEC"].decode('utf-8'))
+		print("Librawspec version:", h5file.attrs["VERSION_LIBRAWSPEC"].decode('utf-8'))
+		print("cuFFT version:", h5file.attrs["VERSION_CUFFT"].decode('utf-8'))
+		print("HDF version:", h5file.attrs["VERSION_HDF"].decode('utf-8'))
+		print("Bitshuffle:", h5file.attrs["BITSHUFFLE"].decode('utf-8'))
 
 
 def cmd_tool(args=None):

--- a/blimpy/h5diag.py
+++ b/blimpy/h5diag.py
@@ -42,11 +42,11 @@ def examine(filename):
     print("h5diag: header:", read_header(h5file))
     print("h5diag: data shape:", h5file["data"].shape)
     if version >= 1.999:
-		print("Rawspec version:", h5file.attrs["VERSION_RAWSPEC"].decode('utf-8'))
-		print("Librawspec version:", h5file.attrs["VERSION_LIBRAWSPEC"].decode('utf-8'))
-		print("cuFFT version:", h5file.attrs["VERSION_CUFFT"].decode('utf-8'))
-		print("HDF version:", h5file.attrs["VERSION_HDF"].decode('utf-8'))
-		print("Bitshuffle:", h5file.attrs["BITSHUFFLE"].decode('utf-8'))
+        print("Rawspec version:", h5file.attrs["VERSION_RAWSPEC"].decode('utf-8'))
+        print("Librawspec version:", h5file.attrs["VERSION_LIBRAWSPEC"].decode('utf-8'))
+        print("cuFFT version:", h5file.attrs["VERSION_CUFFT"].decode('utf-8'))
+        print("HDF5 library version:", h5file.attrs["VERSION_HDF5"].decode('utf-8'))
+        print("Bitshuffle:", h5file.attrs["BITSHUFFLE"].decode('utf-8'))
 
 
 def cmd_tool(args=None):

--- a/blimpy/io/hdf_reader.py
+++ b/blimpy/io/hdf_reader.py
@@ -26,10 +26,12 @@ def examine_h5(h5):
         verblob = h5.attrs["VERSION"]
     else:
         oops("examine_h5: HDF5 VERSION attribute missing")
-    try:
+    if type(verblob) == str:
+        version = float(verblob)
+    elif type(verblob) == bytes or type(verblob) == np.bytes_:
         version = float(verblob.decode("utf-8"))
-    except:
-        oops("examine_h5: HDF5 VERSION attribute is corrupted, saw {}".format(verblob))	
+    else:
+        oops("examine_h5: HDF5 VERSION attribute is neither str nor bytes, saw {}".format(verblob))
     if not "data" in h5:
         oops("examine_h5: HDF5 data matrix missing")
     if h5["data"].ndim != 3:

--- a/blimpy/io/hdf_reader.py
+++ b/blimpy/io/hdf_reader.py
@@ -23,13 +23,13 @@ def examine_h5(h5):
     if not classstr in ["FILTERBANK", b"FILTERBANK"]:
         oops("examine_h5: Expected HDF5 CLASS attribute to be 'FILTERBANK' but saw '{}'".format(classstr))
     if "VERSION" in h5.attrs:
-    	verblob = h5.attrs["CLASS"]
+        verblob = h5.attrs["VERSION"]
     else:
         oops("examine_h5: HDF5 VERSION attribute missing")
     try:
-    	version = float(str(verblob))
+        version = float(verblob.decode("utf-8"))
     except:
-     	oops("examine_h5: HDF5 VERSION attribute is corrupted")	
+        oops("examine_h5: HDF5 VERSION attribute is corrupted, saw {}".format(verblob))	
     if not "data" in h5:
         oops("examine_h5: HDF5 data matrix missing")
     if h5["data"].ndim != 3:
@@ -47,7 +47,7 @@ def examine_h5(h5):
     except:
         oops("examine_h5: HDF5 End-diagonal data corruption")
 
-	return version
+    return version
 
 
 class H5Reader(Reader):

--- a/blimpy/io/hdf_reader.py
+++ b/blimpy/io/hdf_reader.py
@@ -19,15 +19,21 @@ def examine_h5(h5):
     if "CLASS" in h5.attrs:
         classstr = h5.attrs["CLASS"]
     else:
-        oops("HDF5 CLASS attribute missing")
+        oops("examine_h5: HDF5 CLASS attribute missing")
     if not classstr in ["FILTERBANK", b"FILTERBANK"]:
-        oops("Expected HDF5 CLASS attribute to be 'FILTERBANK' but saw '{}'".format(classstr))
-    if not "VERSION" in h5.attrs:
-        oops("HDF5 VERSION attribute missing")
+        oops("examine_h5: Expected HDF5 CLASS attribute to be 'FILTERBANK' but saw '{}'".format(classstr))
+    if "VERSION" in h5.attrs:
+    	verblob = h5.attrs["CLASS"]
+    else:
+        oops("examine_h5: HDF5 VERSION attribute missing")
+    try:
+    	version = float(str(verblob))
+    except:
+     	oops("examine_h5: HDF5 VERSION attribute is corrupted")	
     if not "data" in h5:
-        oops("HDF5 data matrix missing")
+        oops("examine_h5: HDF5 data matrix missing")
     if h5["data"].ndim != 3:
-        oops("Expected HDF5 data.ndim to be 3 but saw '{}'".format(h5["data"].ndim))
+        oops("examine_h5: Expected HDF5 data.ndim to be 3 but saw '{}'".format(h5["data"].ndim))
     try:
         xx = h5["data"][-1][0][0]
     except:
@@ -40,6 +46,8 @@ def examine_h5(h5):
         xx = h5["data"][-1][0][-1]
     except:
         oops("examine_h5: HDF5 End-diagonal data corruption")
+
+	return version
 
 
 class H5Reader(Reader):
@@ -75,7 +83,7 @@ class H5Reader(Reader):
         self.filesize = self.filestat.st_size/(1024.0**2)
         self.load_data = load_data
         self.h5 = h5py.File(self.filename, mode='r')
-        examine_h5(self.h5)
+        _ = examine_h5(self.h5)
         self.read_header()
         self.file_size_bytes = os.path.getsize(self.filename)  # In bytes
         self.n_ints_in_file = self.h5["data"].shape[self.time_axis] #

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ setup.py -- setup script for use of packages.
 """
 from setuptools import setup, find_packages
 
-__version__ = '2.0.32'
+__version__ = '2.0.33'
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
* Address enhancement request #249 .
* It has been observed during pytest on a data centre node that extracting the file-level attribute VERSION can return a bytes object (run in interactive mode) and sometimes a numpy.bytes_ object (pytest).
* Utility match_fils.py refers to nonexistent files on data centre nodes.  Its tempting to remove its test counterpart.
