### PR TITLE
Having trouble with publishing on pypi.

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -3,6 +3,7 @@ This file is a version history of blimpy amendments, beginning with version 2.0.
 <br>
 |    Date    | Version | Contents |
 | :--: | :--: | :-- |
+| 2022-02-03 | 2.0.37 | Having trouble with publishing on pypi. Seems to be stuck on blimpy v2.0.35. |
 | 2022-02-02 | 2.0.36 | Enhance h5diag to show frequency channel information.  |
 | 2022-01-28 | 2.0.35 | Revamp rawhdr (issue #253).  |
 | | | Fix misinterpretation of numbers in guppi.py (issue #254). |

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ setup.py -- setup script for use of packages.
 """
 from setuptools import setup, find_packages
 
-__version__ = '2.0.36.2'
+__version__ = '2.0.37'
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
 Github Actions publish to pypi seems to be stuck on blimpy v2.0.35.