### PR TITLE
Remove cython dependence

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ numpy>=1.19
 six
 setuptools
 matplotlib
-cython
 h5py
 scipy
 hdf5plugin


### PR DESCRIPTION
Is `cython` still required? 